### PR TITLE
Fix self referencing assignments scrum 47

### DIFF
--- a/compiler/src/brainfuck.rs
+++ b/compiler/src/brainfuck.rs
@@ -152,6 +152,7 @@ impl BVM {
 	// TODO: refactor/rewrite this, can definitely be improved with async read/write traits or similar
 	// I don't love that I duplicated this to make it work with js
 	// TODO: this isn't covered by unit tests
+	// TODO: add a maximum step count
 	pub async fn run_async(
 		&mut self,
 		output_callback: &js_sys::Function,

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -226,8 +226,12 @@ This error should never occur."
 							memory_id: mem.id(),
 							index: Some(*index),
 						};
-						scope.push_instruction(Instruction::ClearCell(cell.clone()));
-						_add_expr_to_cell(&mut scope, value, cell)?;
+						if is_self_referencing {
+							_add_self_referencing_expr_to_cell(&mut scope, value, cell, true)?;
+						} else {
+							scope.push_instruction(Instruction::ClearCell(cell.clone()));
+							_add_expr_to_cell(&mut scope, value, cell)?;
+						}
 					}
 					(
 						VariableTarget::MultiSpread { name: _ },

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -1077,7 +1077,7 @@ fn _add_self_referencing_expr_to_cell(
 			r_panic!("Cannot sum variable \"{source}\" in expression");
 		};
 		//If we have an instance of the original cell being added simply use our temp cell value
-		if source_cell.memory_id == cell.memory_id {
+		if source_cell.memory_id == cell.memory_id && source_cell.index == cell.index {
 			_copy_cell(scope, temp_cell, cell.clone(), constant);
 		} else {
 			_copy_cell(scope, source_cell, cell.clone(), constant);

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -126,9 +126,9 @@ fn main() -> Result<(), String> {
 		let mut bvm = BVM::new(config, bf_program.chars().collect());
 
 		if args.input.is_some() {
-			bvm.run(&mut Cursor::new(args.input.unwrap()), &mut stdout())?;
+			bvm.run(&mut Cursor::new(args.input.unwrap()), &mut stdout(), None)?;
 		} else {
-			bvm.run(&mut stdin(), &mut stdout())?;
+			bvm.run(&mut stdin(), &mut stdout(), None)?;
 		}
 	} else {
 		print!("{bf_program}");

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -178,7 +178,7 @@ fn parse_add_clause(clause: &[Token]) -> Result<Vec<Clause>, String> {
 		},
 	};
 	//Check if this add clause self references
-	self_referencing = expr.clone().check_self_referencing(&var);
+	self_referencing = expr.check_self_referencing(&var);
 
 	clauses.push(Clause::AddToVariable {
 		var,
@@ -227,7 +227,7 @@ fn parse_set_clause(clause: &[Token]) -> Result<Vec<Clause>, String> {
 
 	let expr = Expression::parse(&clause[i..(clause.len() - 1)])?;
 	//Check if this set clause self references
-	self_referencing = expr.clone().check_self_referencing(&var);
+	self_referencing = expr.check_self_referencing(&var);
 
 	clauses.push(Clause::SetVariable {
 		var,
@@ -999,7 +999,7 @@ impl Expression {
 	}
 
 	//Recursively Check If This Is Self Referencing
-	pub fn check_self_referencing(self, parent: &VariableTarget) -> bool {
+	pub fn check_self_referencing(&self, parent: &VariableTarget) -> bool {
 		let expr = self;
 		let mut self_referencing = false;
 		//For Expressions Recurse otherwise we only need to check variable references to see if they are self referencing
@@ -1015,7 +1015,7 @@ impl Expression {
 			}
 			//If we are referencing the parent variable return true
 			Expression::VariableReference(var) => {
-				if var == *parent {
+				if *var == *parent {
 					self_referencing = true;
 				}
 			}

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -157,6 +157,7 @@ fn parse_let_clause(clause: &[Token]) -> Result<Clause, String> {
 fn parse_add_clause(clause: &[Token]) -> Result<Vec<Clause>, String> {
 	let mut clauses: Vec<Clause> = Vec::new();
 	let mut i = 0usize;
+	let mut self_referencing = false;
 	let (var, len) = parse_var_target(&clause[i..])?;
 	i += len;
 
@@ -176,8 +177,14 @@ fn parse_add_clause(clause: &[Token]) -> Result<Vec<Clause>, String> {
 			summands: vec![raw_expr],
 		},
 	};
+	//Check if this add clause self references
+	self_referencing = expr.clone().check_self_referencing(&var);
 
-	clauses.push(Clause::AddToVariable { var, value: expr });
+	clauses.push(Clause::AddToVariable {
+		var,
+		value: expr,
+		is_self_referencing: self_referencing,
+	});
 
 	Ok(clauses)
 }
@@ -185,15 +192,17 @@ fn parse_add_clause(clause: &[Token]) -> Result<Vec<Clause>, String> {
 // currently just syntax sugar, should make it actually do post/pre increments
 fn parse_increment_clause(clause: &[Token]) -> Result<Clause, String> {
 	let (var, _) = parse_var_target(&clause[2..])?;
-
+	//An increment clause can never be self referencing since it just VAR++
 	Ok(match (&clause[0], &clause[1]) {
 		(Token::Plus, Token::Plus) => Clause::AddToVariable {
 			var,
 			value: Expression::NaturalNumber(1),
+			is_self_referencing: false,
 		},
 		(Token::Minus, Token::Minus) => Clause::AddToVariable {
 			var,
 			value: Expression::NaturalNumber((-1i8 as u8) as usize),
+			is_self_referencing: false,
 		},
 		_ => {
 			r_panic!("Invalid pattern in increment clause: {clause:#?}");
@@ -206,6 +215,7 @@ fn parse_set_clause(clause: &[Token]) -> Result<Vec<Clause>, String> {
 	// TODO: what do we do about arrays and strings?
 	let mut clauses: Vec<Clause> = Vec::new();
 	let mut i = 0usize;
+	let mut self_referencing = false;
 	let (var, len) = parse_var_target(&clause[i..])?;
 	i += len;
 
@@ -216,8 +226,14 @@ fn parse_set_clause(clause: &[Token]) -> Result<Vec<Clause>, String> {
 	i += 1;
 
 	let expr = Expression::parse(&clause[i..(clause.len() - 1)])?;
+	//Check if this set clause self references
+	self_referencing = expr.clone().check_self_referencing(&var);
 
-	clauses.push(Clause::SetVariable { var, value: expr });
+	clauses.push(Clause::SetVariable {
+		var,
+		value: expr,
+		is_self_referencing: self_referencing,
+	});
 
 	Ok(clauses)
 }
@@ -981,6 +997,35 @@ impl Expression {
 
 		Ok((imm_sum.0, additions, subtractions))
 	}
+
+	//Recursively Check If This Is Self Referencing
+	pub fn check_self_referencing(self, parent: &VariableTarget) -> bool {
+		let expr = self;
+		let mut self_referencing = false;
+		//For Expressions Recurse otherwise we only need to check variable references to see if they are self referencing
+		match expr {
+			Expression::SumExpression { sign, summands } => {
+				//Loop through sub expressions and check them all recursively if we find a self reference early we can break
+				for summand in summands {
+					if summand.check_self_referencing(parent) {
+						self_referencing = true;
+						break;
+					}
+				}
+			}
+			//If we are referencing the parent variable return true
+			Expression::VariableReference(var) => {
+				if var == *parent {
+					self_referencing = true;
+				}
+			}
+			//Ignore these since they are not self referencing
+			Expression::ArrayLiteral(_)
+			| Expression::StringLiteral(_)
+			| Expression::NaturalNumber(_) => {}
+		}
+		self_referencing
+	}
 }
 
 // TODO: add multiplication
@@ -1017,10 +1062,12 @@ pub enum Clause {
 	AddToVariable {
 		var: VariableTarget,
 		value: Expression,
+		is_self_referencing: bool,
 	},
 	SetVariable {
 		var: VariableTarget,
 		value: Expression,
+		is_self_referencing: bool,
 	},
 	AssertVariableValue {
 		var: VariableTarget,

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -398,6 +398,26 @@ output '0' + x;
 	}
 
 	#[test]
+    fn assignments_6() {
+        let program = String::from(
+            r#";
+let x[2] = [4, 5];
+x[0] = x[0] + 4;
+x[1] = x[1] - 3;
+
+x[0] += '0';
+x[1] += '0';
+output *x;
+        "#,
+        );
+        let input = String::from("");
+        let desired_output = String::from("82");
+        let output = compile_and_run(program, input).expect("");
+        println!("{output}");
+        assert_eq!(desired_output, output)
+    }
+
+	#[test]
 	fn loops_1() {
 		let program = String::from(
 			"

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -355,12 +355,27 @@ let x = 5;
 output '0' + x;
 x += 1 + x;
 output '0' + x;
+			"#,
+		);
+		let input = String::from("");
+		let desired_output = String::from("5;");
+		let output = compile_and_run(program, input).expect("");
+		println!("{output}");
+		assert_eq!(desired_output, output)
+	}
+
+	#[test]
+	fn assignments_4() {
+		let program = String::from(
+			r#";
+let x = 2;
+output '0' + x;
 x = x + x + x;
 output '0' + x;
 			"#,
 		);
 		let input = String::from("");
-		let desired_output = String::from("5;Q");
+		let desired_output = String::from("26");
 		let output = compile_and_run(program, input).expect("");
 		println!("{output}");
 		assert_eq!(desired_output, output)

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -347,6 +347,22 @@ output '0' + x;
 		println!("{output}");
 		assert_eq!(desired_output, output)
 	}
+	#[test]
+	fn assignments_3() {
+		let program = String::from(
+			r#";
+let x = 5;
+output '0' + x;
+x += 1 + x;
+output '0' + x;
+			"#,
+		);
+		let input = String::from("");
+		let desired_output = String::from("5;");
+		let output = compile_and_run(program, input).expect("");
+		println!("{output}");
+		assert_eq!(desired_output, output)
+	}
 
 	#[test]
 	fn loops_1() {

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -417,6 +417,26 @@ output *x;
         assert_eq!(desired_output, output)
     }
 
+    #[test]
+    fn assignments_7() {
+        let program = String::from(
+            r#";
+let x[2] = [1, 2];
+x[0] = x[1] + 5; // 7
+x[1] = x[0] + x[1]; // 9
+
+x[0] += '0';
+x[1] += '0';
+output *x;
+        "#,
+        );
+        let input = String::from("");
+        let desired_output = String::from("79");
+        let output = compile_and_run(program, input).expect("");
+        println!("{output}");
+        assert_eq!(desired_output, output)
+    }
+
 	#[test]
 	fn loops_1() {
 		let program = String::from(

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -37,6 +37,8 @@ pub mod tests {
 		ENABLE_2D_GRID: false,
 	};
 
+	const TESTING_BVM_MAX_STEPS: usize = 100_000_000;
+
 	fn compile_and_run(program: String, input: String) -> Result<String, String> {
 		// println!("{program}");
 		// compile mastermind
@@ -52,7 +54,12 @@ pub mod tests {
 		let bfs = bf_program.to_string();
 		// println!("{}", bfs);
 		// run generated brainfuck with input
-		Ok(run_code(BVM_CONFIG_1D, bfs, input))
+		Ok(run_code(
+			BVM_CONFIG_1D,
+			bfs,
+			input,
+			Some(TESTING_BVM_MAX_STEPS),
+		))
 	}
 
 	fn compile_program(
@@ -107,7 +114,7 @@ pub mod tests {
 
 		let input = String::from("");
 		let desired_output = String::from("");
-		let output = run_code(BVM_CONFIG_1D, code, input);
+		let output = run_code(BVM_CONFIG_1D, code, input, None);
 		println!("{output}");
 		assert_eq!(desired_output, output)
 	}
@@ -302,6 +309,40 @@ output A;
 		);
 		let input = String::from("");
 		let desired_output = String::from("666666 G");
+		let output = compile_and_run(program, input).expect("");
+		println!("{output}");
+		assert_eq!(desired_output, output)
+	}
+
+	#[test]
+	fn assignments_1() {
+		let program = String::from(
+			r#";
+let x = 5;
+output '0' + x;
+x += 1;
+output '0' + x;
+			"#,
+		);
+		let input = String::from("");
+		let desired_output = String::from("56");
+		let output = compile_and_run(program, input).expect("");
+		println!("{output}");
+		assert_eq!(desired_output, output)
+	}
+
+	#[test]
+	fn assignments_2() {
+		let program = String::from(
+			r#";
+let x = 5;
+output '0' + x;
+x = x + 1;
+output '0' + x;
+			"#,
+		);
+		let input = String::from("");
+		let desired_output = String::from("56");
 		let output = compile_and_run(program, input).expect("");
 		println!("{output}");
 		assert_eq!(desired_output, output)
@@ -581,7 +622,7 @@ output 10;
 		let desired_output = String::from("01231\n");
 		let code = compile_program(program, Some(&OPT_NONE))?.to_string();
 		println!("{}", code);
-		let output = run_code(BVM_CONFIG_1D, code, input);
+		let output = run_code(BVM_CONFIG_1D, code, input, None);
 		println!("{output}");
 		assert_eq!(desired_output, output);
 
@@ -844,7 +885,7 @@ output foo;
 		println!("{code}");
 
 		let input = String::from("");
-		let output = run_code(BVM_CONFIG_1D, code.clone(), input);
+		let output = run_code(BVM_CONFIG_1D, code.clone(), input, None);
 		println!("{output}");
 		assert_eq!(code, ">>>++<<<++++++++++++[->>>++++++++++<<<][-]>>>.");
 		assert_eq!(output, "z");
@@ -937,7 +978,7 @@ bf {
 			",.[-]+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+."
 		);
 
-		let output = run_code(BVM_CONFIG_1D, code, String::from("~"));
+		let output = run_code(BVM_CONFIG_1D, code, String::from("~"), None);
 		assert_eq!(output, "~Hello, World!");
 		Ok(())
 	}
@@ -961,7 +1002,7 @@ bf @3 {
 			">>>,.[-]+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+."
 		));
 
-		let output = run_code(BVM_CONFIG_1D, code, String::from("~"));
+		let output = run_code(BVM_CONFIG_1D, code, String::from("~"), None);
 		assert_eq!(output, "~Hello, World!");
 		Ok(())
 	}
@@ -994,7 +1035,7 @@ assert *str equals 0;
 
 		assert!(code.starts_with(",>,>,<<[+>]<<<[.[-]>]<<<"));
 
-		let output = run_code(BVM_CONFIG_1D, code, String::from("HEY"));
+		let output = run_code(BVM_CONFIG_1D, code, String::from("HEY"), None);
 		assert_eq!(output, "IFZ");
 		Ok(())
 	}
@@ -1024,7 +1065,7 @@ bf {
 		let code = compile_program(program, None)?.to_string();
 		println!("{code}");
 
-		let output = run_code(BVM_CONFIG_1D, code, String::from("line of input\n"));
+		let output = run_code(BVM_CONFIG_1D, code, String::from("line of input\n"), None);
 		assert_eq!(output, "lmijnoef !opfg !ijnopquvtu");
 		Ok(())
 	}
@@ -1063,7 +1104,7 @@ bf {
 		let code = compile_program(program, None)?.to_string();
 		println!("{code}");
 
-		let output = run_code(BVM_CONFIG_1D, code, String::from("hello\n"));
+		let output = run_code(BVM_CONFIG_1D, code, String::from("hello\n"), None);
 		assert_eq!(output, "'h'\n'e'\n'l'\n'l'\n'o'\n");
 		Ok(())
 	}
@@ -1121,7 +1162,7 @@ output 'h';
 		println!("{}", code.clone().to_string());
 		assert_eq!(
 			desired_output,
-			run_code(BVM_CONFIG_1D, code.to_string(), input)
+			run_code(BVM_CONFIG_1D, code.to_string(), input, None)
 		);
 
 		Ok(())
@@ -1145,7 +1186,7 @@ output a + 3;
 
 		let code = compile_program(program, Some(&OPT_ALL))?.to_string();
 		println!("{}", code);
-		assert_eq!(desired_output, run_code(BVM_CONFIG_1D, code, input));
+		assert_eq!(desired_output, run_code(BVM_CONFIG_1D, code, input, None));
 
 		Ok(())
 	}

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -382,6 +382,22 @@ output '0' + x;
 	}
 
 	#[test]
+	fn assignments_5() {
+		let program = String::from(
+			r#";
+let x = 2;
+x = (2 + 3) - ((x + 4) + 1) + 4 - (12) + (3 + 10);
+output '0' + x;
+		"#,
+		);
+		let input = String::from("");
+		let desired_output = String::from("3");
+		let output = compile_and_run(program, input).expect("");
+		println!("{output}");
+		assert_eq!(desired_output, output)
+	}
+
+	#[test]
 	fn loops_1() {
 		let program = String::from(
 			"

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -355,10 +355,12 @@ let x = 5;
 output '0' + x;
 x += 1 + x;
 output '0' + x;
+x = x + x + x;
+output '0' + x;
 			"#,
 		);
 		let input = String::from("");
-		let desired_output = String::from("5;");
+		let desired_output = String::from("5;Q");
 		let output = compile_and_run(program, input).expect("");
 		println!("{output}");
 		assert_eq!(desired_output, output)

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -43,16 +43,16 @@ pub mod tests {
 		// println!("{program}");
 		// compile mastermind
 		let tokens: Vec<Token> = tokenise(&program)?;
-		// println!("{tokens:#?}");
+		println!("{tokens:#?}");
 		let clauses = parse(&tokens)?;
-		// println!("{clauses:#?}");
+		println!("{clauses:#?}");
 		let instructions = Compiler { config: &OPT_NONE }
 			.compile(&clauses, None)?
 			.finalise_instructions(false);
-		// println!("{instructions:#?}");
+		println!("{instructions:#?}");
 		let bf_program = Builder { config: &OPT_NONE }.build(instructions, false)?;
 		let bfs = bf_program.to_string();
-		// println!("{}", bfs);
+		println!("{}", bfs);
 		// run generated brainfuck with input
 		Ok(run_code(
 			BVM_CONFIG_1D,


### PR DESCRIPTION
- Added a new function for adding a self-referencing expression into a cell.
- Added a `is_self_referencing`attribute to the SetVariable and AddToVariable clause
- Added a function that recursively checks expressions to return True if they reference a specific variable
- Updates the `is_self_referencing` attribute when parsing SetVariable and AddToVariable clauses
- Adds unit tests for several cases
- Includes Heaths Timeout changes