### PR TITLE
Adds stack module to standard library

### DIFF
--- a/programs/std/stack
+++ b/programs/std/stack
@@ -1,8 +1,15 @@
+// Credit to @MSMissing for contributing this stack data type.
+
+// Be aware this data type uses embedded Brainfuck operations which may break user programs if not used carefully.
+// The standard library currently lacks a testing framework, so until that is added, use at own risk :)
+
+
 struct stack32 { // STACK CANNOT CONTAIN ZEROES.
-  cell len;
-  cell zero;
-  cell[32] content;
-  cell end; // if this is not equal to zero, panic.
+  cell len          @0;
+  cell temp         @1;
+  cell zero         @2;
+  cell[32] content  @3;
+  cell end          @35; // if this is not equal to zero, panic.
 }
 
 // DOCUMENTATION
@@ -22,13 +29,13 @@ struct stack32 { // STACK CANNOT CONTAIN ZEROES.
 // clear(stack)   - clears the stack. Suggested if a stack is about to go out of scope.
 
 
-fn __move_to_top(struct stack32 stack) {
-  bf @stack.zero clobbers *stack.content {
+fn __zero_to_top() {
+  bf {
     >[>]<
   }
 }
 
-fn __back_to_zero() {
+fn __top_to_zero() {
   bf {
     [<]
   }
@@ -38,14 +45,18 @@ fn push_d(struct stack32 stack, cell value) {
   value -= 1;
   stack.len += 1;
   bf @stack.zero clobbers *stack.content {
-    >[>]+
+    {__zero_to_top();}
+    >+
+    {__top_to_zero();}
   }
-  __back_to_zero();
+
   while value {
     value -= 1;
-    __move_to_top(stack);
-    bf clobbers *stack.content {+}
-    __back_to_zero();
+    bf @stack.zero clobbers *stack.content {
+      {__zero_to_top();}
+      +
+      {__top_to_zero();}
+    }
   }
 }
 
@@ -57,21 +68,29 @@ fn push(struct stack32 stack, cell value) {
 
 fn pop(struct stack32 stack, cell out) {
   stack.len -= 1;
-  out = 0;
-  bf @stack.zero {>[>]<[>+<-]>}
-  bf { [-<< }
-    __back_to_zero();
-    out += 1;
-    __move_to_top(stack);
-  bf { >>]<< }
-  __back_to_zero();
+  bf @stack.zero clobbers *stack.content stack.temp {
+    {__zero_to_top();}
+    [>+<-]>[
+      -<<[<]
+      {
+        cell temp @-1;
+        assert temp unknown;
+        temp += 1;
+      }
+      >[>]>
+    ]
+    <<{__top_to_zero();}
+  }
+  drain stack.temp into out;
 }
 
 fn pop(struct stack32 stack) {
   stack.len -= 1;
-  __move_to_top(stack);
-  bf clobbers *stack.content {[-]<}
-  __back_to_zero();
+  bf @stack.zero clobbers *stack.content {
+    {__zero_to_top();}
+    [-]<
+    {__top_to_zero();}
+  }
 }
 
 fn shift(struct stack32 stack, cell out) {
@@ -83,14 +102,17 @@ fn shift(struct stack32 stack, cell out) {
 
 fn shift(struct stack32 stack) {
   stack.len -= 1;
+  drain stack.content[0];
   bf @stack.content[1] clobbers *stack.content { [[<+>-]>]<<[<]>> }
 }
 
 fn unshift_d(struct stack32 stack, cell value) {
   stack.len += 1;
-  __move_to_top(stack);
-  bf clobbers *stack.content { [[->+<]<] }
-  stack.content[0] = 0;
+  bf @stack.zero clobbers *stack.content {
+    {__zero_to_top();}
+    [[->+<]<]
+  }
+  assert stack.content[0] equals 0;
   drain value into stack.content[0];
 }
 
@@ -146,12 +168,99 @@ fn reverse(struct stack32 stack) {
 }
 
 
+// debug/test code:
+// #include <u8>
+// fn p(cell x) {print(x); output " ("; debug(x); output ")\n";}
+// fn p(struct stack32 s) {
+//   output "STACK:\n";
+//   output "len = "; p(s.len);
+//   output "temp = "; p(s.temp);
+//   output "zero = "; p(s.zero);
+//   output "content[0] = "; p(s.content[0]);
+//   output "content[1] = "; p(s.content[1]);
+//   output "content[2] = "; p(s.content[2]);
+//   output "content[3] = "; p(s.content[3]);
+//   output "content[4] = "; p(s.content[4]);
+//   output "\n";
+// }
+
+// // pushing and popping:
+// output "PUSH/POP TESTING START\n";
+// struct stack32 s1;
+// cell x = 6;
+// p(s1);
+// push_d(s1, x);
+// x += 7;
+// p(s1);
+// push(s1, x);
+// p(s1);
+
+// push(s1, x);
+// p(s1);
+// pop(s1);
+// p(s1);
+
+// cell y;
+// p(y);
+// pop(s1, y);
+// p(y);
+// p(s1);
+// pop(s1, y);
+// p(y);
+// p(s1);
+
+// output "PUSH/POP TESTING END\n\n";
 
 
+// // unshifting and shifting:
+// output "UNSHIFT/SHIFT TESTING START\n";
+// struct stack32 s2;
+// x = 6;
+// p(s2);
+// unshift_d(s2, x);
+// x += 7;
+// p(s2);
+// unshift(s2, x);
+// p(s2);
 
+// x = 255;
+// unshift(s2, x);
+// p(s2);
 
+// struct stack32 snapshot1;
+// copy_stack(s2, snapshot1);
+// struct stack32 snapshot2;
+// copy_stack(s2, snapshot2);
 
+// shift(s2);
+// p(s2);
 
+// y = 0;
+// p(y);
+// shift(s2, y);
+// p(y);
+// p(s2);
+// shift(s2, y);
+// p(y);
+// p(s2);
 
+// output "SNAPSHOTS:\n";
+// p(snapshot1);
+// p(snapshot2);
 
+// move_stack(snapshot1, s2);
+// p(s2);
+// pop(s2);
+// move_stack(s2, snapshot1);
+// copy_stack(snapshot2, s2);
+// shift(s2);
+// reverse(snapshot1);
 
+// output "s2:\n";
+// p(s2);
+// output "snapshot1:\n";
+// p(snapshot1);
+// output "snapshot2:\n";
+// p(snapshot2);
+
+// output "UNSHIFT/SHIFT TESTING END\n\n";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import std_i8 from "../programs/std/i8?raw";
 import std_u8 from "../programs/std/u8?raw";
 import std_u16 from "../programs/std/u16?raw";
 import std_ifp16 from "../programs/std/ifp16?raw";
+import std_stack from "../programs/std/stack?raw";
 
 import "./App.css";
 import Divider from "./components/Divider";
@@ -52,7 +53,7 @@ import {
 const AppContext = createContext<AppContextProps>();
 
 // update this when you want the user to see new syntax
-const MIGRATION_VERSION = 11;
+const MIGRATION_VERSION = 12;
 
 const App: Component = () => {
   const [version, setVersion] = makePersisted(createSignal<number>(), {
@@ -190,6 +191,11 @@ const App: Component = () => {
         id: uuidv4(),
         label: "ifp16",
         rawText: std_ifp16,
+      },
+      {
+        id: uuidv4(),
+        label: "stack",
+        rawText: std_stack,
       },
       {
         id: uuidv4(),


### PR DESCRIPTION
Adds the stack module which users can include to create stack variables.

This will hopefully make it easier to write Mastermind code without having to use inline Brainfuck.

Note that implementing this into the compiler is a better way of adding this, but this was easier for me than figuring out a way to hack it in.